### PR TITLE
docs: remove AI Realtime Video note from main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # ai-worker
 
-> [!NOTE]
-> This branch will explore adding AI inference to realtime video streams. Majority of the commits here will likely change significantly and not intended for production purposes.
-
 > [!WARNING]
 > The AI network is in it's **Beta** phase and although it is ready for production it is still under development. Please report any issues you encounter to the [Livepeer Discord](https://discord.gg/7nbPbTK).
 


### PR DESCRIPTION
This commit removes the AI Realtime video warning note from the mainbranch as it should have been on the
https://github.com/livepeer/ai-worker/tree/realtime-ai-experimental branch.